### PR TITLE
Enhance chat app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # Kiso_Chat
-A Python project to create a chat app with OpenAI API and Streamlit.
+
+A Streamlit chat application powered by OpenAI's APIs and LangChain.
+
+## Features
+
+- Secure handling of the API key via environment variables
+- Asynchronous processing support
+- Configurable model parameters (temperature, max tokens, top p)
+- Multiple chat sessions using a chat ID
+- Streaming of assistant responses
+
+Run the app with:
+
+```bash
+streamlit run kiso_chatgpt.py
+```

--- a/kiso_chatgpt.py
+++ b/kiso_chatgpt.py
@@ -1,61 +1,110 @@
-import streamlit as st
 import os
-
-from langchain.chains import  ConversationChain
+import asyncio
+import streamlit as st
+from langchain.chains import ConversationChain
 from langchain.chat_models import ChatOpenAI
 
-if "messages" not in st.session_state:
-    st.session_state.messages = []
 
-st.title("KiSo - Chat") 
-st.divider()
+class ChatApp:
+    """Streamlit chat application using LangChain."""
 
-with st.sidebar:
-    st.title("KiSo - Chat")
-    apiKey=st.text_input("OpenAI API Key")
-    st.divider()
-    st.empty()
-    model = st.selectbox("Choose a model:", ["gpt-4-1106-preview", "gpt-3.5-turbo-1106"])
-    st.divider()
-    st.empty()
-    if st.button("New Chat :page_facing_up:"):
-        st.session_state.messages = []
+    def __init__(self) -> None:
+        self._init_session()
+        self.params = {}
+        self._setup_sidebar()
+        self._setup_chain()
 
-# The code block you provided is setting up the OpenAI API key, creating an instance of the ChatOpenAI
-# model, and initializing a ConversationChain.
-try:
-    os.environ['OPENAI_API_KEY'] = apiKey 
-    llm = ChatOpenAI(
-        model=model,
-        temperature=1,
-        max_tokens=250,  # Angenommene Anzahl an Tokens
-        top_p=1.0,
-    )
-    
-    inhalt_chain = ConversationChain(llm=llm, verbose=True)
+    def _init_session(self) -> None:
+        if "chats" not in st.session_state:
+            st.session_state["chats"] = {"default": []}
+        if "current_chat" not in st.session_state:
+            st.session_state["current_chat"] = "default"
 
-# The code block you provided is responsible for displaying the chat messages from the history on app
-# rerun and allowing the user to input their question.
-# Display chat messages from history on app rerun
+    def _setup_sidebar(self) -> None:
+        with st.sidebar:
+            st.title("KiSo - Chat")
+            api_key = st.text_input("OpenAI API Key", type="password")
+            if api_key:
+                os.environ["OPENAI_API_KEY"] = api_key
+            st.divider()
 
-    for message in st.session_state.messages:
-        with st.chat_message(message["role"]):
-            st.markdown(message["content"])
+            chat_id = st.text_input("Chat ID", value=st.session_state["current_chat"])
+            model = st.selectbox("Choose a model:", ["gpt-4-1106-preview", "gpt-3.5-turbo-1106"])
+            temperature = st.slider("Temperature", 0.0, 1.0, 1.0, 0.1)
+            max_tokens = st.number_input("Max tokens", min_value=1, max_value=4096, value=250)
+            top_p = st.slider("Top P", 0.0, 1.0, 1.0, 0.05)
 
-    prompt= st.chat_input("Ask your question!")
+            if st.button("New Chat :page_facing_up:"):
+                st.session_state["chats"][chat_id] = []
+            st.session_state["current_chat"] = chat_id
 
-# This code block is responsible for handling the user's question and generating a response from the
-# assistant.
-    if prompt:
-        with st.chat_message("user"):   
-            st.write(prompt)
-            st.session_state.messages.append({"role": "user", "content": prompt})
-        
-        with st.chat_message("assistant"):
-            response = inhalt_chain.predict(input=prompt)
-            st.write(response)
-            st.session_state.messages.append({"role": "assistant", "content": response})
-            
-except Exception as e:
-    st.write(st.write(str(e)))
-           
+            self.params.update(
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                top_p=top_p,
+            )
+
+    def _setup_chain(self) -> None:
+        if "OPENAI_API_KEY" not in os.environ or not os.environ["OPENAI_API_KEY"]:
+            st.warning("API key missing. Enter your OpenAI API key in the sidebar.")
+            self.llm = None
+            return
+        try:
+            self.llm = ChatOpenAI(
+                streaming=True,
+                model=self.params["model"],
+                temperature=self.params["temperature"],
+                max_tokens=self.params["max_tokens"],
+                top_p=self.params["top_p"],
+            )
+            self.chain = ConversationChain(llm=self.llm, verbose=False)
+        except Exception as exc:
+            st.error(f"Failed to initialize model: {exc}")
+            self.llm = None
+
+    def _stream_response(self, prompt: str):
+        for chunk in self.llm.stream(prompt):
+            text = chunk.content
+            if text:
+                yield text
+
+    async def _async_response(self, prompt: str) -> str:
+        return await self.chain.apredict(input=prompt)
+
+    def _display_messages(self) -> None:
+        messages = st.session_state["chats"].setdefault(st.session_state["current_chat"], [])
+        for message in messages:
+            with st.chat_message(message["role"]):
+                st.markdown(message["content"])
+
+    def run(self) -> None:
+        st.title("KiSo - Chat")
+        st.divider()
+
+        if not self.llm:
+            return
+
+        chat_id = st.session_state["current_chat"]
+        messages = st.session_state["chats"].setdefault(chat_id, [])
+
+        self._display_messages()
+
+        prompt = st.chat_input("Ask your question!")
+        if prompt:
+            with st.chat_message("user"):
+                st.write(prompt)
+            messages.append({"role": "user", "content": prompt})
+
+            with st.chat_message("assistant"):
+                try:
+                    response = st.write_stream(self._stream_response(prompt))
+                except Exception:
+                    response = asyncio.run(self._async_response(prompt))
+                    st.write(response)
+
+            messages.append({"role": "assistant", "content": response})
+
+
+if __name__ == "__main__":
+    ChatApp().run()


### PR DESCRIPTION
## Summary
- modularize Streamlit app into a `ChatApp` class
- secure API key handling and add more sidebar controls
- support multiple chat sessions and response streaming
- document new capabilities

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c29daac883208b37ecb0b3d04efb